### PR TITLE
Sentinel Support

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
@@ -105,7 +105,7 @@ namespace StackExchange.Redis
 
         private bool? allowAdmin, abortOnConnectFail, highPrioritySocketThreads, resolveDns, ssl;
 
-        private string clientName, serviceName, password, tieBreaker, sslHost, configChannel;
+        private string clientName, serviceName, password, tieBreaker, sslHost, configChannel;        
 
         private CommandMap commandMap;
 
@@ -113,7 +113,9 @@ namespace StackExchange.Redis
 
         private int? keepAlive, syncTimeout, connectTimeout, responseTimeout, writeBuffer, connectRetry, configCheckSeconds, defaultDatabase;
 
-        private Proxy? proxy;
+        private Proxy? proxy;        
+
+        private ConfigurationOptions sentinelMasterConfigurationOptions;
 
         /// <summary>
         /// A LocalCertificateSelectionCallback delegate responsible for selecting the certificate used for authentication; note
@@ -242,7 +244,12 @@ namespace StackExchange.Redis
         /// If enabled the ConnectionMultiplexer will not re-resolve DNS
         /// when attempting to re-connect after a connection failure.
         /// </summary>
-        public bool ResolveDns { get { return resolveDns.GetValueOrDefault(); } set { resolveDns = value; } }
+        public bool ResolveDns { get { return resolveDns.GetValueOrDefault(); } set { resolveDns = value; } }        
+        
+        /// <summary>
+        ///  Configuration options for the master that Sentinel connects to
+        /// </summary>
+        public ConfigurationOptions SentinelMasterConfigurationOptions { get { return sentinelMasterConfigurationOptions; } set { sentinelMasterConfigurationOptions = value; } }
 
         /// <summary>
         /// The service name used to resolve a service via sentinel
@@ -347,7 +354,8 @@ namespace StackExchange.Redis
                 ChannelPrefix = ChannelPrefix.Clone(),
                 SocketManager = SocketManager,
                 connectRetry = connectRetry,
-                configCheckSeconds = configCheckSeconds,
+                configCheckSeconds = configCheckSeconds,                
+                sentinelMasterConfigurationOptions = sentinelMasterConfigurationOptions,
                 responseTimeout = responseTimeout,
 				defaultDatabase = defaultDatabase,
             };

--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -708,6 +708,35 @@ namespace StackExchange.Redis
             return false;
         }
 
+		 private static async Task<Task<T>> WaitFirstNonNullIgnoreErrorsAsync<T>(Task<T>[] tasks)
+        {
+            if (tasks == null) throw new ArgumentNullException("tasks");
+            if (tasks.Length == 0) return null;
+            var typeNullable = (Nullable.GetUnderlyingType(typeof(T)) != null);
+            var taskList = tasks.Cast<Task>().ToList();
+
+            try
+            {
+                while (taskList.Count() > 0)
+                {
+#if NET40
+                    var allTasksAwaitingAny = TaskEx.WhenAny(taskList).ObserveErrors();
+#else
+                    var allTasksAwaitingAny = Task.WhenAny(taskList).ObserveErrors();
+#endif
+                    var result = await allTasksAwaitingAny.ForAwait();
+                    taskList.Remove((Task<T>)result);
+                    if (((Task<T>)result).IsFaulted) continue;
+                    if ((!typeNullable) || ((Task<T>)result).Result != null)
+                        return (Task<T>)result;
+                }
+            }
+            catch
+            { }
+
+            return null;
+        }
+		
 
         /// <summary>
         /// Raised when a hash-slot has been relocated
@@ -874,6 +903,12 @@ namespace StackExchange.Redis
                 }
                 if (!task.Result) throw ExceptionFactory.UnableToConnect(muxer.failureMessage);
                 killMe = null;
+
+                if(muxer.ServerSelectionStrategy.ServerType == ServerType.Sentinel)
+                {
+                    // Initialize the Sentinel handlers
+                    muxer.InitializeSentinel(log);
+                }
                 return muxer;
             }
             finally
@@ -984,6 +1019,21 @@ namespace StackExchange.Redis
         internal static long LastGlobalHeartbeatSecondsAgo => unchecked(Environment.TickCount - VolatileWrapper.Read(ref lastGlobalHeartbeatTicks)) / 1000;
 
         internal CompletionManager UnprocessableCompletionManager => unprocessableCompletionManager;
+		internal EndPoint GetConfiguredMasterForService(int timeoutmillis = -1)
+        {
+            Task<EndPoint>[] sentinelMasters = this.serverSnapshot
+                        .Where(s => s.ServerType == ServerType.Sentinel)
+                        .Select(s => this.GetServer(s.EndPoint).SentinelGetMasterAddressByNameAsync(RawConfig.ServiceName))
+                        .ToArray();
+
+            Task<Task<EndPoint>> firstCompleteRequest = WaitFirstNonNullIgnoreErrorsAsync(sentinelMasters);
+            if (!firstCompleteRequest.Wait(timeoutmillis))
+                throw new TimeoutException("Timeout resolving master for service");
+            if (firstCompleteRequest.Result.Result == null)
+                throw new Exception("Unable to determine master");
+
+            return firstCompleteRequest.Result.Result;
+        }		
 
         /// <summary>
         /// Obtain a pub/sub subscriber connection to the specified server
@@ -1192,7 +1242,7 @@ namespace StackExchange.Redis
                     return false;
                 }
                 Trace("Starting reconfiguration...");
-                Trace(blame != null, "Blaming: " + Format.ToString(blame));
+                Trace(blame != null, "Blaming: " + Format.ToString(blame));                                               
 
                 LogLocked(log, Configuration);
                 LogLocked(log, "");
@@ -1820,6 +1870,218 @@ namespace StackExchange.Redis
 
         internal ServerSelectionStrategy ServerSelectionStrategy => serverSelectionStrategy;
 
+        internal ConnectionMultiplexer sentinelMasterConnection;
+
+        /// <summary>
+        /// Contains a ConnectionMultiplexer connected to the current master as dictated by 
+        /// Sentinel config
+        /// </summary>
+        public ConnectionMultiplexer SentinelMasterConnection { get { return sentinelMasterConnection; } }
+
+        internal EndPoint currentSentinelMasterEndPoint = null;
+
+        internal System.Timers.Timer sentinelMasterReconnectTimer = null;
+
+        /// <summary>
+        ///  Initializes the sentinel connection and creates the
+        ///  ConnectionMultiplexer for the master
+        /// </summary>
+        internal void InitializeSentinel(TextWriter log = null)
+        {
+            if(log == null) log = TextWriter.Null;
+
+            // Are we a sentinel setup?
+            if(ServerSelectionStrategy.ServerType == ServerType.Sentinel)
+            {
+                if(String.IsNullOrEmpty(configuration.ServiceName))
+                {
+                    Trace("Sentinel configuration missing ServiceName");
+                    throw new ArgumentException("No ServiceName configured for Sentinel connection.");
+                }
+
+                Trace(String.Format("Configuring Sentinel connection with ServiceName '{0}'", configuration.ServiceName));
+
+                if(this.sentinelMasterConnection == null)
+                {
+                    if(configuration.SentinelMasterConfigurationOptions == null)
+                    {
+                        Trace("Missing config for Sentinel Master.");
+                        throw new ArgumentException("Missing configuration options for Sentinel Master");
+                    }
+
+                    // Clear out the configuration
+                    ConfigurationOptions sconfig = configuration.SentinelMasterConfigurationOptions;
+                    sconfig.ServiceName = null;
+                    sconfig.EndPoints.Clear();
+                    sconfig.AbortOnConnectFail = false;
+
+                    // Get an initial endpoint
+                    EndPoint initialMasterEndPoint = null;
+
+                    do 
+                    {
+                        initialMasterEndPoint = GetConfiguredMasterForService();
+                    } while(initialMasterEndPoint == null);
+
+                    sconfig.EndPoints.Add(initialMasterEndPoint);
+
+                    this.sentinelMasterConnection = ConnectionMultiplexer.Connect(sconfig, log);
+
+                    // Subscribe to sentinel change events
+                    ISubscriber sub = GetSubscriber();
+                    if(sub.SubscribedEndpoint("+switch-master") == null)
+                    {
+                        sub.Subscribe("+switch-master", (channel, message) => {
+                            string[] messageParts = ((string)message).Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                            EndPoint switchBlame = Format.TryParseEndPoint(string.Format("{0}:{1}", messageParts[1], messageParts[2]));
+                            SwitchMaster(switchBlame);
+                        });
+
+                    }                    
+
+                    // If we lose connection to a sentinel server,
+                    // We need to reconfigure to make sure we still have
+                    // a subscription to the +switch-master channel.
+                    this.ConnectionFailed += (sender, e) => {
+                        // Reconfigure to get subscriptions back online
+                        ReconfigureAsync(false, true, log, e.EndPoint, "Lost sentinel connection", false).Wait();
+                    };
+
+                    // Subscribe to new sentinels being added
+                    if(sub.SubscribedEndpoint("+sentinel") == null)
+                    {
+                        sub.Subscribe("+sentinel", (channel, message) => {
+                            UpdateSentinelAddressList();
+                        });
+                    }
+
+                    // Attach to reconnect event to ensure proper connection to the new master
+                    sentinelMasterConnection.ConnectionRestored += (sender, e) => {
+                        ConnectionMultiplexer connection = (ConnectionMultiplexer)sender;
+
+                        if(sentinelMasterReconnectTimer != null)
+                        {
+                            sentinelMasterReconnectTimer.Stop();
+                            sentinelMasterReconnectTimer = null;
+                        }
+
+                        // Run a swithc to make sure we have update-to-date 
+                        // information about which master we should connect to
+                        SwitchMaster(e.EndPoint);
+    
+                        try
+                        {
+                            // Verify that the reconnected endpoint is a master,
+                            // and the correct one otherwise we should reconnect
+                            if(connection.GetServer(e.EndPoint).IsSlave || e.EndPoint != currentSentinelMasterEndPoint)
+                            {
+                                // Wait for things to smooth out
+                                Thread.Sleep(200);
+
+                                // This isn't a master, so try connecting again
+                                SwitchMaster(e.EndPoint);
+                            }
+                        }
+                        catch(Exception)
+                        {
+                            // If we get here it means that we tried to reconnect to a server that is no longer
+                            // considered a master by Sentinel and was removed from the list of endpoints.
+
+                            // Wait for things to smooth out
+                            Thread.Sleep(200);
+
+                            // If we caught an exception, we may have gotten a stale endpoint
+                            // we are not aware of, so retry
+                            SwitchMaster(e.EndPoint);
+                        }
+                    };
+
+                    // If we lost the connection, run a switch to a least try and get updated info about the master
+                    sentinelMasterConnection.ConnectionFailed += (sender, e) => {
+                        // Periodically check to see if we can reconnect to the proper master.
+                        // This is here in case we lost our subscription to a good sentinel instance
+                        // or if we miss the published master change
+                        if(sentinelMasterReconnectTimer == null)
+                        {
+                            sentinelMasterReconnectTimer = new System.Timers.Timer(1000);
+                            sentinelMasterReconnectTimer.AutoReset = true;                            
+
+                            sentinelMasterReconnectTimer.Elapsed += (o, t) => {
+                                SwitchMaster(e.EndPoint);
+                            };
+                            
+                            sentinelMasterReconnectTimer.Start();
+                        }                        
+                    };
+
+                    // Perform the initial switchover
+                    SwitchMaster(configuration.EndPoints[0], log);
+                }
+            } 
+        }
+
+        /// <summary>
+        ///  Switches the SentinelMasterConnection over to a new master.
+        /// </summary>
+        /// <param name="switchBlame"></param>
+        internal void SwitchMaster(EndPoint switchBlame, TextWriter log = null)
+        {            
+            if(log == null) log = TextWriter.Null;
+
+            ConnectionMultiplexer sconnection = sentinelMasterConnection;
+            // Get new master
+            EndPoint masterEndPoint = null;
+
+            do 
+            {
+                masterEndPoint = GetConfiguredMasterForService();
+            } while(masterEndPoint == null);
+
+            currentSentinelMasterEndPoint = masterEndPoint;
+
+            if (!sconnection.servers.Contains(masterEndPoint))
+            {
+                sconnection.configuration.EndPoints.Clear();
+                sconnection.servers.Clear();
+                sconnection.serverSnapshot = new ServerEndPoint[0];
+                sconnection.configuration.EndPoints.Add(masterEndPoint);
+                Trace(string.Format("Switching master to {0}", masterEndPoint));
+                // Trigger a reconfigure                            
+                sconnection.ReconfigureAsync(false, false, log, switchBlame, "master switch", false, CommandFlags.PreferMaster).Wait();
+            }
+            
+            UpdateSentinelAddressList();        
+        }
+
+        internal void UpdateSentinelAddressList(int timeoutmillis = 500)
+        {
+            Task<EndPoint[]>[] sentinels = this.serverSnapshot
+                        .Where(s => s.ServerType == ServerType.Sentinel)
+                        .Select(s => this.GetServer(s.EndPoint).SentinelGetSentinelAddresses(RawConfig.ServiceName))
+                        .ToArray();
+
+            Task<Task<EndPoint[]>> firstCompleteRequest = WaitFirstNonNullIgnoreErrorsAsync(sentinels);
+
+            // Ignore errors, as having an updated sentinel list is
+            // not essential
+            if (!firstCompleteRequest.Wait(timeoutmillis))
+                return;
+            if (firstCompleteRequest.Result.Result == null)
+                return;
+                        
+            bool hasNew = false;
+            foreach(EndPoint newSentinel in firstCompleteRequest.Result.Result.Where(x => !configuration.EndPoints.Contains(x)))
+            {
+                hasNew = true;
+                configuration.EndPoints.Add(newSentinel);
+            }
+
+            if(hasNew)
+            {
+                // Reconfigure the sentinel multiplexer if we added new endpoints
+                ReconfigureAsync(false, true, null, configuration.EndPoints[0], "Updating Sentinel List", false).Wait();
+            }
+        }
 
         /// <summary>
         /// Close all connections and release all resources associated with this object

--- a/StackExchange.Redis/StackExchange/Redis/IServer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/IServer.cs
@@ -440,6 +440,15 @@ namespace StackExchange.Redis
         Task<EndPoint> SentinelGetMasterAddressByNameAsync(string serviceName, CommandFlags flags = CommandFlags.None);
 
         /// <summary>
+        /// Returns the ip and port numbers of all known Sentinels
+        /// for the given service name.
+        /// </summary>
+        /// <param name="serviveName">the sentinel service name</param>
+        /// <param name="flags"></param>
+        /// <returns>a list of the sentinel ips and ports</returns>
+        Task<EndPoint[]> SentinelGetSentinelAddresses(string serviveName, CommandFlags flags = CommandFlags.None);
+
+        /// <summary>
         /// Show the state and info of the specified master.
         /// </summary>
         /// <param name="serviceName">the sentinel service name</param>

--- a/StackExchange.Redis/StackExchange/Redis/RedisLiterals.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisLiterals.cs
@@ -68,6 +68,7 @@ namespace StackExchange.Redis
             GETMASTERADDRBYNAME = "GET-MASTER-ADDR-BY-NAME",
 //            RESET = "RESET",
             FAILOVER = "FAILOVER", 
+            SENTINELS = "SENTINELS",
 
             // Sentinel Literals as of 2.8.4
             MONITOR = "MONITOR",

--- a/StackExchange.Redis/StackExchange/Redis/RedisServer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/RedisServer.cs
@@ -754,6 +754,12 @@ namespace StackExchange.Redis
             return ExecuteAsync(msg, ResultProcessor.SentinelMasterEndpoint);
         }
 
+        public Task<EndPoint[]> SentinelGetSentinelAddresses(string serviceName, CommandFlags flags = CommandFlags.None)
+        {
+            var msg = Message.Create(-1, flags, RedisCommand.SENTINEL, RedisLiterals.SENTINELS, (RedisValue)serviceName);
+            return ExecuteAsync(msg, ResultProcessor.SentinelAddressesEndPoints);            
+        }
+
         public KeyValuePair<string, string>[] SentinelMaster(string serviceName, CommandFlags flags = CommandFlags.None)
         {
             var msg = Message.Create(-1, flags, RedisCommand.SENTINEL, RedisLiterals.MASTER, (RedisValue)serviceName);

--- a/StackExchange.Redis/StackExchange/Redis/ResultProcessor.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ResultProcessor.cs
@@ -84,6 +84,9 @@ namespace StackExchange.Redis
         public static readonly ResultProcessor<EndPoint>
             SentinelMasterEndpoint = new SentinelGetMasterAddressByNameProcessor();
 
+        public static readonly ResultProcessor<EndPoint[]>
+            SentinelAddressesEndPoints = new SentinelGetSentinelAddresses();
+
         public static readonly ResultProcessor<KeyValuePair<string, string>[][]>
             SentinelArrayOfArrays = new SentinelArrayOfArraysProcessor();
         
@@ -1237,7 +1240,74 @@ namespace StackExchange.Redis
                             return true;
                         }
                         break;
+                    case ResultType.SimpleString:
+                        //We don't want to blow up if the master is not found
+                        if (result.IsNull)
+                            return true;
+                        break;
                 }
+                return false;
+            }
+        }
+
+        sealed class SentinelGetSentinelAddresses : ResultProcessor<EndPoint[]>
+        {
+            protected override bool SetResultCore(PhysicalConnection connection, Message message, RawResult result)
+            {
+                List<EndPoint> endPoints = new List<EndPoint>();
+                
+                switch (result.Type)
+                {
+                    case ResultType.MultiBulk:
+                        RawResult[] items = result.GetItems();
+
+                        foreach(RawResult item in items)
+                        {
+                            var arr = item.GetItemsAsValues();
+                            String ip = null;
+                            String portStr = null;
+
+                            for(int i = 0; i < arr.Length && (ip == null || portStr == null); i += 2)
+                            {
+                                String name = arr[i];
+                                String value = arr[i + 1];
+
+                                switch(name)
+                                {
+                                    case "ip":
+                                        ip = value;
+                                        break;
+
+                                    case "port":
+                                        portStr = value;
+                                        break;
+
+                                    default:
+                                        break;
+                                }
+                            }
+                            
+                            int port;
+                            if (ip != null && portStr != null && int.TryParse(portStr, out port))
+                            {
+                                endPoints.Add(Format.ParseEndPoint(ip, port));     
+                            }                                                     
+                        }
+                        break;
+                        
+                    case ResultType.SimpleString:
+                        //We don't want to blow up if the master is not found
+                        if (result.IsNull)
+                            return true;
+                        break;
+                }
+
+                if(endPoints.Count > 0)
+                {
+                    SetResult(message, endPoints.ToArray());
+                    return true;
+                }
+
                 return false;
             }
         }


### PR DESCRIPTION
Initial pass at adding Sentinel support to the ConnectionMultiplexer. Usage:

``` C#
ConfigurationOptions sentinelConfig = new ConfigurationOptions();
sentinelConfig.ServiceName = "ServiceNameValue";
sentinelConfig.EndPoints.Add("127.0.0.1", 26379);
sentinelConfig.EndPoints.Add("127.0.0.2", 26379);
sentinelConfig.EndPoints.Add("127.0.0.4", 26379);
sentinelConfig.TieBreaker = "";
sentinelConfig.DefaultVersion = new Version(3, 0);

// Add the configuration for the masters that we will connect to
ConfigurationOptions masterConfig = new ConfigurationOptions();
sentinelConfig.SentinelMasterConfignfigurationOptions = masterConfig;

// Connect!
ConnectionMultiplexer sentinelConnection = ConnectionMultiplexer.Connect(sentinelConfig);

// When we need to perform a command against the masters, use the master
connection
ConnectionMultiplexer masterConnection = sentinelConnection.SentinelMasterConnection;
```

Pulled the initial code from PR #121 and updated to fit into the latest version. Added support for handling various reconnect scenarios, as outlined in the client documentation at http://redis.io/topics/sentinel-clients, even if the client misses the "change master" event from the Sentinel servers. Also added support updating the connection's list of Sentinel nodes as they are added after the connection has been started.
