### PR TITLE
Add 'subscription' PhysicalBridge to master after failover reconfigur…

### DIFF
--- a/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
+++ b/StackExchange.Redis/StackExchange/Redis/ConnectionMultiplexer.cs
@@ -1300,7 +1300,7 @@ namespace StackExchange.Redis
                             "subscription" PhysicalBridge.
 
                             */
-                            if (!server.IsSlave && server.EndPoint.Equals(currentSentinelMasterEndPoint))
+                            if (!server.IsSlave && server.EndPoint == currentSentinelMasterEndPoint)
                             {
                                 if (CommandMap.IsAvailable(RedisCommand.SUBSCRIBE))
                                 {
@@ -1984,11 +1984,9 @@ namespace StackExchange.Redis
     
             try
             {
-                var s = connection.GetServer(e.EndPoint);
-
                 // Verify that the reconnected endpoint is a master,
                 // and the correct one otherwise we should reconnect
-                if (s.IsSlave || !e.EndPoint.Equals(connection.currentSentinelMasterEndPoint))
+                if (connection.GetServer(e.EndPoint).IsSlave || e.EndPoint != connection.currentSentinelMasterEndPoint)
                 {
                     // Wait for things to smooth out
                     Thread.Sleep(200);
@@ -2033,7 +2031,7 @@ namespace StackExchange.Redis
         internal EndPoint GetConfiguredMasterForService(String serviceName, int timeoutmillis = -1)
         {
             Task<EndPoint>[] sentinelMasters = this.serverSnapshot
-                        .Where(s => s.ServerType == ServerType.Sentinel)
+                        .Where(s => s.ServerType == ServerType.Sentinel && s.IsConnected)
                         .Select(s => this.GetServer(s.EndPoint).SentinelGetMasterAddressByNameAsync(serviceName))
                         .ToArray();
 


### PR DESCRIPTION
Hi,

Thanks for the Sentinel feature you had provided.

I observed that during Sentinel failover, the Stackexchange library tried to re-subscribe the current master to any channel the previous master might have subscribed to. But, the operation failed because the current master didn't have any "subscription" physical bridge associated to it. I have added a small change on top your sentinel feature, which basically enables "Subscription" physical bridge for a master (if it is) after a "failover". This allows a new master to get subscribed to any channel from that of the previous master during "restore" & "failure" events.

Please do let me know in case of any issues.